### PR TITLE
Make policy state sharing Unicode-safe (URL-safe base64)

### DIFF
--- a/docs/ai-policy-generator/script.js
+++ b/docs/ai-policy-generator/script.js
@@ -27,6 +27,25 @@ document.addEventListener('DOMContentLoaded', function() {
     const isInIframe = window.self !== window.top;
 
     // URL Parameter Handling
+    function toBase64Url(text) {
+        const bytes = new TextEncoder().encode(text);
+        const binary = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/g, '');
+    }
+
+    function fromBase64Url(base64url) {
+        const normalizedBase64 = base64url
+            .replace(/-/g, '+')
+            .replace(/_/g, '/');
+        const paddedBase64 = normalizedBase64 + '='.repeat((4 - (normalizedBase64.length % 4)) % 4);
+        const binary = atob(paddedBase64);
+        const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
+        return new TextDecoder().decode(bytes);
+    }
+
     function encodeFormState() {
         const formData = new FormData(form);
         const state = {
@@ -45,13 +64,13 @@ document.addEventListener('DOMContentLoaded', function() {
             cf: document.getElementById('customCitationFormat')?.value || ''   // cf for custom citation format
         };
         
-        // Convert to base64 to make it more compact
-        return btoa(JSON.stringify(state));
+        // Convert to URL-safe base64 so shared links work with all Unicode characters
+        return toBase64Url(JSON.stringify(state));
     }
 
     function decodeFormState(encodedState) {
         try {
-            const state = JSON.parse(atob(encodedState));
+            const state = JSON.parse(fromBase64Url(encodedState));
             
             // Set radio buttons
             if (state.s) {


### PR DESCRIPTION
### Motivation
- The policy form state was serialized with `btoa`/`atob`, which fails for non-ASCII Unicode (accents, emoji, non-Latin scripts) and produces `+`, `/`, `=` characters that are not ideal in URLs. 
- Shared `policy` query parameters must reliably round-trip arbitrary Unicode input when users copy or embed links.

### Description
- Added `toBase64Url` and `fromBase64Url` helpers that use `TextEncoder`/`TextDecoder` to correctly handle UTF-8 and convert to a URL-safe Base64 representation (replace `+`/`/` and remove padding). 
- Replaced direct `btoa(JSON.stringify(state))` with `toBase64Url(JSON.stringify(state))` in `encodeFormState`. 
- Replaced `JSON.parse(atob(encodedState))` with `JSON.parse(fromBase64Url(encodedState))` in `decodeFormState` to accept both URL-safe and normal Base64 by normalizing and padding before decoding. 
- Changes are applied in `docs/ai-policy-generator/script.js` and preserve existing behavior while improving Unicode and URL-safety.

### Testing
- Ran a syntax check with `node --check docs/ai-policy-generator/script.js`, which succeeded. 
- Executed a Node smoke test that encodes a JSON string containing accented text and emoji with `toBase64Url` and decodes it with `fromBase64Url`, verifying the encoded output contains no `+`, `/`, or `=` characters and the decoded text exactly matches the original; the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f70e6f8483249716233d2c2f4c93)